### PR TITLE
travis.yml: fail travis faster while no tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ notifications:
 
 # skip travis build until we have tests
 # https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build
-before_install: false
-install: false
+before_install:
+  - false
+install:
+  - false
 
 rvm:
   - 2.2.4 # what's on the production VM as of 2017-10-30

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ notifications:
 # skip travis build until we have tests
 # https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build
 before_install: false
+install: false
 
 rvm:
   - 2.2.4 # what's on the production VM as of 2017-10-30

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ install:
 rvm:
   - 2.2.4 # what's on the production VM as of 2017-10-30
 #  - 2.4.2 # what we'd like
+
+cache: bundler


### PR DESCRIPTION
skipping the bundle install makes the travis build fail faster and with less processing.